### PR TITLE
Fix/lint warnings

### DIFF
--- a/apps/example/lib/util.dart
+++ b/apps/example/lib/util.dart
@@ -131,7 +131,7 @@ Future<T?> showLoading<T>({
       builder: (_) => PopScope(
         canPop: false,
         child: Container(
-          color: Theme.of(context).primaryColor.withOpacity(0.6),
+          color: Theme.of(context).primaryColor.withValues(alpha: 0.6),
           child: const Center(
             child: SizedBox(
               width: 150,

--- a/apps/example/lib/views/create_stake_view.dart
+++ b/apps/example/lib/views/create_stake_view.dart
@@ -138,7 +138,7 @@ class RecipientForm extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: Theme.of(context).primaryColor.withOpacity(0.2),
+      color: Theme.of(context).primaryColor.withValues(alpha: 0.2),
       child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: Column(

--- a/apps/example/lib/views/create_transaction_view.dart
+++ b/apps/example/lib/views/create_transaction_view.dart
@@ -183,7 +183,7 @@ class RecipientForm extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: Theme.of(context).primaryColor.withOpacity(0.2),
+      color: Theme.of(context).primaryColor.withValues(alpha: 0.2),
       child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: Column(

--- a/apps/example/lib/views/create_wallet_view.dart
+++ b/apps/example/lib/views/create_wallet_view.dart
@@ -47,7 +47,7 @@ class _CreateWalletViewState extends State<CreateWalletView> {
             path: path,
             password: password,
             seedType: _selectedSalType!,
-            networkType: 1 // testnet
+            networkType: 1, // testnet
           );
           break;
 

--- a/apps/example/lib/views/display_transactions_view.dart
+++ b/apps/example/lib/views/display_transactions_view.dart
@@ -337,8 +337,8 @@ class _DisplayTransactionsViewState extends State<DisplayTransactionsView> {
           padding: const EdgeInsets.all(8),
           decoration: BoxDecoration(
             color: isReceived
-                ? Colors.green.withOpacity(0.1)
-                : Colors.red.withOpacity(0.1),
+                ? Colors.green.withValues(alpha: 0.1)
+                : Colors.red.withValues(alpha: 0.1),
             borderRadius: BorderRadius.circular(8),
           ),
           child: Icon(
@@ -362,9 +362,9 @@ class _DisplayTransactionsViewState extends State<DisplayTransactionsView> {
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
                 decoration: BoxDecoration(
-                  color: Colors.blue.withOpacity(0.1),
+                  color: Colors.blue.withValues(alpha: 0.1),
                   borderRadius: BorderRadius.circular(8),
-                  border: Border.all(color: Colors.blue.withOpacity(0.3)),
+                  border: Border.all(color: Colors.blue.withValues(alpha: 0.3)),
                 ),
                 child: Row(
                   mainAxisSize: MainAxisSize.min,
@@ -390,9 +390,9 @@ class _DisplayTransactionsViewState extends State<DisplayTransactionsView> {
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
               decoration: BoxDecoration(
-                color: statusColor.withOpacity(0.1),
+                color: statusColor.withValues(alpha: 0.1),
                 borderRadius: BorderRadius.circular(12),
-                border: Border.all(color: statusColor.withOpacity(0.3)),
+                border: Border.all(color: statusColor.withValues(alpha: 0.3)),
               ),
               child: Text(
                 transaction.isPending
@@ -615,10 +615,10 @@ class _DisplayTransactionsViewState extends State<DisplayTransactionsView> {
       margin: const EdgeInsets.only(bottom: 16),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: Theme.of(context).primaryColor.withOpacity(0.05),
+        color: Theme.of(context).primaryColor.withValues(alpha: 0.05),
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
-          color: Theme.of(context).primaryColor.withOpacity(0.1),
+          color: Theme.of(context).primaryColor.withValues(alpha: 0.1),
         ),
       ),
       child: Column(

--- a/apps/example/lib/widgets/info_item.dart
+++ b/apps/example/lib/widgets/info_item.dart
@@ -10,7 +10,7 @@ class InfoItem extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.all(16),
       child: Container(
-        color: Theme.of(context).primaryColor.withOpacity(0.4),
+        color: Theme.of(context).primaryColor.withValues(alpha: 0.4),
         child: Padding(
           padding: const EdgeInsets.all(8.0),
           child: Column(

--- a/packages/cs_salvium/lib/src/models/transaction.dart
+++ b/packages/cs_salvium/lib/src/models/transaction.dart
@@ -1,5 +1,4 @@
 import '../../cs_salvium.dart';
-import '../enums/tx_type.dart';
 
 /// Represents a Monero (or Wownero) transaction for a given wallet.
 class Transaction {

--- a/packages/cs_salvium/lib/src/models/transaction.dart
+++ b/packages/cs_salvium/lib/src/models/transaction.dart
@@ -1,4 +1,6 @@
 import '../../cs_salvium.dart';
+// ignore: unnecessary_import
+import '../enums/tx_type.dart'; // TODO: use directly once Transaction exposes typed asset/type fields
 
 /// Represents a Monero (or Wownero) transaction for a given wallet.
 class Transaction {

--- a/packages/cs_salvium/lib/src/wallets/salvium_wallet.dart
+++ b/packages/cs_salvium/lib/src/wallets/salvium_wallet.dart
@@ -37,9 +37,7 @@ class SalviumWallet extends Wallet {
   Pointer<Void>? _walletPointer;
   Pointer<Void> _getWalletPointer() {
     if (_walletPointer == null) {
-      throw Exception(
-        "SalviumWallet was closed!",
-      );
+      throw Exception("SalviumWallet was closed!");
     }
     return _walletPointer!;
   }
@@ -66,7 +64,8 @@ class SalviumWallet extends Wallet {
         sal_ffi.getTransactionInfoTimestamp(infoPointer) * 1000,
       ),
       type: TxType.values.firstWhere(
-          (e) => e.value == sal_ffi.getTransactionInfoType(infoPointer),),
+        (e) => e.value == sal_ffi.getTransactionInfoType(infoPointer),
+      ),
       minConfirms: MinConfirms.salvium,
     );
   }
@@ -351,17 +350,16 @@ class SalviumWallet extends Wallet {
     required String viewKey,
     int networkType = 0,
     int restoreHeight = 0,
-  }) async =>
-      await restoreWalletFromKeys(
-        path: path,
-        password: password,
-        language: "", // not used when the viewKey is not empty
-        address: address,
-        viewKey: viewKey,
-        spendKey: "",
-        networkType: networkType,
-        restoreHeight: restoreHeight,
-      );
+  }) async => await restoreWalletFromKeys(
+    path: path,
+    password: password,
+    language: "", // not used when the viewKey is not empty
+    address: address,
+    viewKey: viewKey,
+    spendKey: "",
+    networkType: networkType,
+    restoreHeight: restoreHeight,
+  );
 
   /// Restores a Salvium wallet from private keys and address.
   ///
@@ -565,10 +563,8 @@ class SalviumWallet extends Wallet {
 
   // ===========================================================================
   // special check to see if wallet exists
-  static bool isWalletExist(String path) => sal_wm_ffi.walletExists(
-        _walletManagerPointer,
-        path,
-      );
+  static bool isWalletExist(String path) =>
+      sal_wm_ffi.walletExists(_walletManagerPointer, path);
 
   // ===========================================================================
   // === Internal overrides ====================================================
@@ -579,11 +575,7 @@ class SalviumWallet extends Wallet {
     _coinsPointer = sal_ffi.getCoinsPointer(_getWalletPointer());
     final pointerAddress = _coinsPointer!.address;
     await Isolate.run(() {
-      sal_ffi.refreshCoins(
-        Pointer.fromAddress(
-          pointerAddress,
-        ),
-      );
+      sal_ffi.refreshCoins(Pointer.fromAddress(pointerAddress));
     });
   }
 
@@ -596,19 +588,14 @@ class SalviumWallet extends Wallet {
     final pointerAddress = _transactionHistoryPointer!.address;
 
     await Isolate.run(() {
-      sal_ffi.refreshTransactionHistory(
-        Pointer.fromAddress(
-          pointerAddress,
-        ),
-      );
+      sal_ffi.refreshTransactionHistory(Pointer.fromAddress(pointerAddress));
     });
   }
 
   @override
   @protected
-  int transactionCount() => sal_ffi.getTransactionHistoryCount(
-        _transactionHistoryPointer!,
-      );
+  int transactionCount() =>
+      sal_ffi.getTransactionHistoryCount(_transactionHistoryPointer!);
 
   // ===========================================================================
   // === Overrides =============================================================
@@ -652,10 +639,7 @@ class SalviumWallet extends Wallet {
 
     sal_ffi.checkWalletStatus(_getWalletPointer());
 
-    sal_ffi.setTrustedDaemon(
-      _getWalletPointer(),
-      arg: trusted,
-    );
+    sal_ffi.setTrustedDaemon(_getWalletPointer(), arg: trusted);
   }
 
   // @override
@@ -843,19 +827,16 @@ class SalviumWallet extends Wallet {
 
   @override
   BigInt getBalance({int accountIndex = 0}) => BigInt.from(
-        sal_ffi.getWalletBalance(
-          _getWalletPointer(),
-          accountIndex: accountIndex,
-        ),
-      );
+    sal_ffi.getWalletBalance(_getWalletPointer(), accountIndex: accountIndex),
+  );
 
   @override
   BigInt getUnlockedBalance({int accountIndex = 0}) => BigInt.from(
-        sal_ffi.getWalletUnlockedBalance(
-          _getWalletPointer(),
-          accountIndex: accountIndex,
-        ),
-      );
+    sal_ffi.getWalletUnlockedBalance(
+      _getWalletPointer(),
+      accountIndex: accountIndex,
+    ),
+  );
 
   // @override
   // List<Account> getAccounts({bool includeSubaddresses = false}) {
@@ -1023,9 +1004,13 @@ class SalviumWallet extends Wallet {
         final coinInfoPointer = sal_ffi.getCoinInfoPointer(_coinsPointer!, i);
 
         // ignore: unused_local_variable
-        final assetType = sal_ffi.getAssetForCoinsInfo(coinInfoPointer); // TODO: populate Output.asset when field is added
+        final assetType = sal_ffi.getAssetForCoinsInfo(
+          coinInfoPointer,
+        ); // TODO: populate Output.asset when field is added
         // ignore: unused_local_variable
-        final txType = sal_ffi.getTypeForCoinsInfo(coinInfoPointer); // TODO: populate Output.type when field is added
+        final txType = sal_ffi.getTypeForCoinsInfo(
+          coinInfoPointer,
+        ); // TODO: populate Output.type when field is added
         final hash = sal_ffi.getHashForCoinsInfo(coinInfoPointer);
 
         if (hash.isNotEmpty) {
@@ -1036,8 +1021,9 @@ class SalviumWallet extends Wallet {
               address: sal_ffi.getAddressForCoinsInfo(coinInfoPointer),
               hash: hash,
               keyImage: sal_ffi.getKeyImageForCoinsInfo(coinInfoPointer),
-              value:
-                  BigInt.from(sal_ffi.getAmountForCoinsInfo(coinInfoPointer)),
+              value: BigInt.from(
+                sal_ffi.getAmountForCoinsInfo(coinInfoPointer),
+              ),
               isFrozen: sal_ffi.isFrozenCoinsInfo(coinInfoPointer),
               isUnlocked: sal_ffi.isUnlockedCoinsInfo(coinInfoPointer),
               vout: sal_ffi.getInternalOutputIndexForCoinsInfo(coinInfoPointer),
@@ -1174,8 +1160,9 @@ class SalviumWallet extends Wallet {
       sal_ffi.checkPendingTransactionStatus(pendingTxPointer);
 
       return PendingTransaction(
-        amount:
-            BigInt.from(sal_ffi.getPendingTransactionAmount(pendingTxPointer)),
+        amount: BigInt.from(
+          sal_ffi.getPendingTransactionAmount(pendingTxPointer),
+        ),
         fee: BigInt.from(sal_ffi.getPendingTransactionFee(pendingTxPointer)),
         txid: sal_ffi.getPendingTransactionTxid(pendingTxPointer),
         hex: sal_ffi.getPendingTransactionHex(pendingTxPointer),
@@ -1228,8 +1215,9 @@ class SalviumWallet extends Wallet {
       sal_ffi.checkPendingTransactionStatus(pendingTxPointer);
 
       return PendingTransaction(
-        amount:
-            BigInt.from(sal_ffi.getPendingTransactionAmount(pendingTxPointer)),
+        amount: BigInt.from(
+          sal_ffi.getPendingTransactionAmount(pendingTxPointer),
+        ),
         fee: BigInt.from(sal_ffi.getPendingTransactionFee(pendingTxPointer)),
         txid: sal_ffi.getPendingTransactionTxid(pendingTxPointer),
         hex: sal_ffi.getPendingTransactionHex(pendingTxPointer),
@@ -1255,10 +1243,9 @@ class SalviumWallet extends Wallet {
     if (preferredInputs != null) {
       processedInputs = await checkAndProcessInputs(
         inputs: preferredInputs,
-        sendAmount: outputs.map((e) => e.amount).fold(
-              BigInt.zero,
-              (p, e) => p + e,
-            ),
+        sendAmount: outputs
+            .map((e) => e.amount)
+            .fold(BigInt.zero, (p, e) => p + e),
         sweep: sweep,
       );
     } else {
@@ -1287,15 +1274,12 @@ class SalviumWallet extends Wallet {
       sal_ffi.checkPendingTransactionStatus(pendingTxPointer);
 
       return PendingTransaction(
-        amount:
-            BigInt.from(sal_ffi.getPendingTransactionAmount(pendingTxPointer)),
+        amount: BigInt.from(
+          sal_ffi.getPendingTransactionAmount(pendingTxPointer),
+        ),
         fee: BigInt.from(sal_ffi.getPendingTransactionFee(pendingTxPointer)),
-        txid: sal_ffi.getPendingTransactionTxid(
-          pendingTxPointer,
-        ),
-        hex: sal_ffi.getPendingTransactionHex(
-          pendingTxPointer,
-        ),
+        txid: sal_ffi.getPendingTransactionTxid(pendingTxPointer),
+        hex: sal_ffi.getPendingTransactionHex(pendingTxPointer),
         pointerAddress: pendingTxPointer.address,
       );
     } finally {
@@ -1310,24 +1294,17 @@ class SalviumWallet extends Wallet {
     // TODO: check if the return value should be used in any way or if it is ok to rely on the status check below?
     final _ = await Isolate.run(() {
       return sal_ffi.commitPendingTransaction(
-        Pointer<Void>.fromAddress(
-          tx.pointerAddress,
-        ),
+        Pointer<Void>.fromAddress(tx.pointerAddress),
       );
     });
 
     sal_ffi.checkPendingTransactionStatus(
-      Pointer<Void>.fromAddress(
-        tx.pointerAddress,
-      ),
+      Pointer<Void>.fromAddress(tx.pointerAddress),
     );
   }
 
   @override
-  Future<String> signMessage(
-    String message,
-    String address,
-  ) async {
+  Future<String> signMessage(String message, String address) async {
     final pointerAddress = _getWalletPointer().address;
     return await Isolate.run(() {
       return sal_ffi.signMessageWith(

--- a/packages/cs_salvium/lib/src/wallets/salvium_wallet.dart
+++ b/packages/cs_salvium/lib/src/wallets/salvium_wallet.dart
@@ -5,6 +5,8 @@ import 'package:meta/meta.dart';
 
 import '../../cs_salvium.dart';
 import '../deprecated/get_height_by_date.dart';
+// ignore: unnecessary_import
+import '../enums/tx_type.dart'; // TODO: use directly once Output exposes typed asset/type fields
 import '../ffi_bindings/salvium_wallet_bindings.dart' as sal_ffi;
 import '../ffi_bindings/salvium_wallet_manager_bindings.dart' as sal_wm_ffi;
 
@@ -1020,6 +1022,10 @@ class SalviumWallet extends Wallet {
       for (int i = 0; i < count; i++) {
         final coinInfoPointer = sal_ffi.getCoinInfoPointer(_coinsPointer!, i);
 
+        // ignore: unused_local_variable
+        final assetType = sal_ffi.getAssetForCoinsInfo(coinInfoPointer); // TODO: populate Output.asset when field is added
+        // ignore: unused_local_variable
+        final txType = sal_ffi.getTypeForCoinsInfo(coinInfoPointer); // TODO: populate Output.type when field is added
         final hash = sal_ffi.getHashForCoinsInfo(coinInfoPointer);
 
         if (hash.isNotEmpty) {

--- a/packages/cs_salvium/lib/src/wallets/salvium_wallet.dart
+++ b/packages/cs_salvium/lib/src/wallets/salvium_wallet.dart
@@ -5,7 +5,6 @@ import 'package:meta/meta.dart';
 
 import '../../cs_salvium.dart';
 import '../deprecated/get_height_by_date.dart';
-import '../enums/tx_type.dart';
 import '../ffi_bindings/salvium_wallet_bindings.dart' as sal_ffi;
 import '../ffi_bindings/salvium_wallet_manager_bindings.dart' as sal_wm_ffi;
 
@@ -65,7 +64,7 @@ class SalviumWallet extends Wallet {
         sal_ffi.getTransactionInfoTimestamp(infoPointer) * 1000,
       ),
       type: TxType.values.firstWhere(
-          (e) => e.value == sal_ffi.getTransactionInfoType(infoPointer)),
+          (e) => e.value == sal_ffi.getTransactionInfoType(infoPointer),),
       minConfirms: MinConfirms.salvium,
     );
   }
@@ -1021,8 +1020,6 @@ class SalviumWallet extends Wallet {
       for (int i = 0; i < count; i++) {
         final coinInfoPointer = sal_ffi.getCoinInfoPointer(_coinsPointer!, i);
 
-        final asset_type = sal_ffi.getAssetForCoinsInfo(coinInfoPointer);
-        final tx_type = sal_ffi.getTypeForCoinsInfo(coinInfoPointer);
         final hash = sal_ffi.getHashForCoinsInfo(coinInfoPointer);
 
         if (hash.isNotEmpty) {

--- a/packages/cs_salvium/test/models/transaction_test.dart
+++ b/packages/cs_salvium/test/models/transaction_test.dart
@@ -1,5 +1,4 @@
 import 'package:cs_salvium/cs_salvium.dart';
-import 'package:cs_salvium/src/enums/tx_type.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/packages/cs_salvium/test/models/transaction_test.dart
+++ b/packages/cs_salvium/test/models/transaction_test.dart
@@ -1,4 +1,6 @@
 import 'package:cs_salvium/cs_salvium.dart';
+// ignore: unnecessary_import
+import 'package:cs_salvium/src/enums/tx_type.dart'; // TODO: use directly once Transaction exposes typed asset/type fields
 import 'package:test/test.dart';
 
 void main() {


### PR DESCRIPTION
I am adding CI to cs_salvium, etc so that the outputs can be consumed by workflows further upstream. In addition to the necessary builds, I'm starting with linting and testing. I was going to just loosen CI so it passes despite these, but I thought I would try to learn how to determine if those FFI calls are truly unused, and the withOpacity change seems simple.
We'll just close this PR and loosen the CI if you determine this isn't the way to go or I've made a mistake that asset_type or tx_type are on the Output and Stack needs them or something like that.
